### PR TITLE
Responds to wget, curl, and fetch(?)

### DIFF
--- a/swagip/templates/index.html
+++ b/swagip/templates/index.html
@@ -1,1 +1,3 @@
 <title>SwagIP</title>
+
+{{ ip }}

--- a/swagip/views.py
+++ b/swagip/views.py
@@ -4,7 +4,7 @@ File: views.py
 Purpose: routes for the app
 """
 
-from flask import render_template, request
+from flask import render_template, request, jsonify
 from swagip import app
 import time
 import json
@@ -14,4 +14,16 @@ import json
 def index():
     """ Function to return index page
     """
-    return render_template('index.html')
+    userAgent = request.user_agent.string
+
+    # Werkzeug stores the X-Forwarded-For header ip list in
+    # access_route.
+    if request.access_route:
+        ip = request.access_route[0]
+    else:
+        ip = request.remote_addr
+
+    if "Wget" in userAgent or "fetch" in userAgent or "curl" in userAgent:
+        return ip, 200
+    else:
+        return render_template('index.html', ip=ip)


### PR DESCRIPTION
Checks user-agent for wget, curl, and fetch

The ip address gets iffy since we will be running this behind a load balancer / reverse proxy.
So we need to grab the "X-Forwarded-For" out of the header. Thankfully werkzeug does this for us automatically.

Solves #2 
